### PR TITLE
Update longest_increasing_subsequence.cc

### DIFF
--- a/Library/dynamic_programming/longest_increasing_subsequence.cc
+++ b/Library/dynamic_programming/longest_increasing_subsequence.cc
@@ -57,6 +57,6 @@ vector<T> longest_increasing_subsequence(const vector<T> &x) {
 
 int main() {
   vector<int> x = {3,1,4,2};
-  auto y = lis(x);
+  auto y = longest_increasing_subsequence(x);
   for (auto a: y) cout << a << " "; cout << endl;
 }


### PR DESCRIPTION
Corrected compilation error generated due to mismatch between name of function defined and function called.